### PR TITLE
fix(toolbar): make "Thumbs", "Tags", "Zen mode" functions work as default composer

### DIFF
--- a/static/less/overrides.less
+++ b/static/less/overrides.less
@@ -29,6 +29,23 @@
 		top: 6px;
 		left: -0.5px;
 	}
+
+	.ql-thumbs {
+		position: relative;
+
+		&[data-format="thumbs"][data-count]:after {
+			content: attr(data-count);
+			background: @brand-info;
+			color: white;
+			font-weight: 600;
+			position: absolute;
+			left: 50%;
+			bottom: 50%;
+			padding: 0px 5px;
+			border-radius: 5px;
+			font-size: 0.75em;
+		}
+	}
 }
 
 /* Safari bug.. */

--- a/static/lib/quill-nbb.js
+++ b/static/lib/quill-nbb.js
@@ -285,6 +285,8 @@ window.quill.init = function (targetEl, data, callback) {
 					}
 				}
 			});
+			// Show thumbs count
+			toolbarEl.find(`.ql-thumbs`).attr('data-format', 'thumbs');
 
 			$(window).trigger('action:quill.load', quill);
 
@@ -404,6 +406,28 @@ window.quill.configureToolbar = async (targetEl, data) => {
 	const toolbarHandlers = formatting.getDispatchTable();
 	const group = [];
 	data.formatting.forEach((option) => {
+		// -- Default composer compatibility: thumbs, tags, zen
+		if (option.name === 'thumbs') {
+			if (config.allowTopicsThumbnail && data.composerData.isMain) {
+				toolbar.handlers[option.name] = toolbarHandlers[option.name].bind(data.postContainer);
+				group.push(option.name);
+			}
+			return;
+		}
+		if (option.name === 'tags') {
+			if (option.visibility.desktop && ((data.composerData.isMain && option.visibility.main) || (!data.composerData.isMain && option.visibility.reply))) {
+				toolbar.handlers[option.name] = toolbarHandlers[option.name].bind(data.postContainer);
+				group.push(option.name);
+			}
+			return;
+		}
+		if (option.name === 'zen') {
+			if (option.visibility.desktop && ((data.composerData.isMain && option.visibility.main) || (!data.composerData.isMain && option.visibility.reply))) {
+				toolbar.handlers[option.name] = toolbarHandlers[option.name].bind(data.postContainer);
+				group.push(option.name);
+			}
+			return;
+		}
 		group.push(option.name);
 		toolbar.handlers[option.name] = function () {
 			// Chicken-wrapper to pass additional values to handlers (to match composer-default behaviour)


### PR DESCRIPTION
These changes make some toolbar items workable.